### PR TITLE
Adding $ to style for proper binding

### DIFF
--- a/paper-swatch-picker-content.html
+++ b/paper-swatch-picker-content.html
@@ -110,7 +110,7 @@ Custom property | Description | Default
 
     <paper-listbox slot="dropdown-content" id="container">
       <template is="dom-repeat" items="{{colorList}}">
-        <paper-item class="color" style="color:[[item]]">{{item}}</paper-item>
+        <paper-item class="color" style$="color:[[item]]">{{item}}</paper-item>
       </template>
     </paper-listbox>
   </template>


### PR DESCRIPTION
Safari can throw an error in some cases unless the binding is properly set.